### PR TITLE
bbot bash setting file.

### DIFF
--- a/bbot.setup
+++ b/bbot.setup
@@ -1,0 +1,5 @@
+# ROS network settings for bumpybot
+export ROS_MASTER_URI=http://192.168.2.5:11311
+export ROS_IP=192.168.2.5
+xhost local:hcrl-bumpybot
+alias record_bumpybot_hw='rosbag record -e "/trikey/base_controller/(.*)" /joint_states /servo_temp'


### PR DESCRIPTION
Source this file to set ROS configuration instead of adding them to your ~/.bashrc 
Should also override existing .bashrc configurations with the appropriate ones to use bumpybot.